### PR TITLE
Harden event schema SEO and canonical host deployment

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,0 +1,11 @@
+Options -Indexes
+RewriteEngine On
+
+# Consolidate every duplicate www URL on the canonical non-www host while
+# preserving its path and query string. HTTPS is terminated by Plesk before
+# this rule is evaluated.
+RewriteCond %{HTTP_HOST} ^www\.mysteryland\.biz$ [NC]
+RewriteRule ^ https://mysteryland.biz%{REQUEST_URI} [R=301,END,NE]
+
+ErrorDocument 404 /404.html
+

--- a/scripts/deploy/ssh-deploy-astro.mjs
+++ b/scripts/deploy/ssh-deploy-astro.mjs
@@ -15,6 +15,9 @@ const options = {
 };
 
 if (!existsSync(join(options.distPath, 'index.html'))) throw new Error('Missing Astro build output in dist');
+if (!existsSync(join(options.distPath, '.htaccess'))) {
+  throw new Error('Missing canonical host redirect in dist/.htaccess');
+}
 if (!options.targetPath.startsWith('/') || !options.releaseRoot.startsWith('/')) throw new Error('Deploy paths must be absolute');
 if (!Number.isInteger(options.keepReleases) || options.keepReleases < 1 || options.keepReleases > 30) {
   throw new Error('DEPLOY_KEEP_RELEASES must be between 1 and 30');

--- a/src/components/EventSeo.astro
+++ b/src/components/EventSeo.astro
@@ -1,6 +1,11 @@
 ---
 import { organizersFromTags } from '../data/organizers.mjs';
-import { googleEventStatus, isoDate, isCurrentOrFutureEvent } from '../scripts/lib/event-schema.mjs';
+import {
+  googleEventOffer,
+  googleEventStatus,
+  isoDate,
+  isCurrentOrFutureEvent,
+} from '../scripts/lib/event-schema.mjs';
 
 const route = Astro.locals.starlightRoute;
 const entry = route?.entry;
@@ -48,12 +53,6 @@ function organizerType(category: string) {
   return category === 'Lesung' ? 'Person' : 'Organization';
 }
 
-function offerAvailability(eventStatus: string) {
-  return eventStatus === 'https://schema.org/EventScheduled'
-    ? 'https://schema.org/InStock'
-    : 'https://schema.org/SoldOut';
-}
-
 const title = text(data.title);
 const description = text(data.description);
 const canonical = absoluteUrl(data.canonicalUrl || Astro.url.pathname);
@@ -74,6 +73,13 @@ const explicitOrganizers = values(data.organizer);
 const organizers = explicitOrganizers.length ? explicitOrganizers : organizersFromTags(values(data.tags));
 const eventId = canonical ? `${canonical}#event` : '';
 const eventStatus = googleEventStatus(data.status);
+const offer = googleEventOffer({
+  price,
+  eventStatus,
+  startDate,
+  url: canonical,
+  name: ticketCategory,
+});
 const isGoogleEvent = isEvent && isCurrentOrFutureEvent(endDate);
 
 // Google event rich results are intended for events people can still attend.
@@ -116,17 +122,7 @@ const eventJsonLd = isGoogleEvent ? {
       name,
     })),
   } : {}),
-  ...(price !== undefined ? {
-    offers: {
-      '@type': 'Offer',
-      price,
-      priceCurrency: 'EUR',
-      availability: offerAvailability(eventStatus),
-      validFrom: startDate,
-      url: canonical,
-      ...(ticketCategory ? { name: ticketCategory } : {}),
-    },
-  } : {}),
+  ...(offer ? { offers: offer } : {}),
 } : null;
 ---
 

--- a/src/components/EventSeo.astro
+++ b/src/components/EventSeo.astro
@@ -1,5 +1,5 @@
 ---
-import { organizersFromTags } from '../data/organizers.mjs';
+import { organizerUrl, organizersFromTags } from '../data/organizers.mjs';
 import {
   googleEventOffer,
   googleEventStatus,
@@ -117,10 +117,15 @@ const eventJsonLd = isGoogleEvent ? {
     })),
   } : {}),
   ...(organizers.length ? {
-    organizer: organizers.map((name) => ({
-      '@type': organizerType(category),
-      name,
-    })),
+    organizer: organizers.map((name) => {
+      const url = organizerUrl(name);
+
+      return {
+        '@type': organizerType(category),
+        name,
+        ...(url ? { url } : {}),
+      };
+    }),
   } : {}),
   ...(offer ? { offers: offer } : {}),
 } : null;

--- a/src/content/docs/events/2026/2026-07-25.mdx
+++ b/src/content/docs/events/2026/2026-07-25.mdx
@@ -11,6 +11,8 @@ tour: "BOB!Fest 2026"
 
 category: "Festival"
 
+organizer: ["RADIO BOB GmbH & Co. KG", "HockeyPark Betriebs GmbH & Co. KG"]
+
 ticketCategory: "Stehplatz Innenraum"
 
 status: "scheduled"

--- a/src/content/docs/events/2026/2026-09-01.mdx
+++ b/src/content/docs/events/2026/2026-09-01.mdx
@@ -13,6 +13,8 @@ artist: ["OMD"]
 
 category: "Konzert"
 
+organizer: "ZFR Event GmbH & Co. KG"
+
 ticketCategory: "Stehplatz"
 
 support: "TBA"

--- a/src/content/docs/events/2026/2026-12-25.mdx
+++ b/src/content/docs/events/2026/2026-12-25.mdx
@@ -13,6 +13,8 @@ artist: ["Broilers"]
 
 category: "Konzert"
 
+organizer: "Kingstar GmbH"
+
 ticketCategory: "Stehplatz Innenraum"
 
 support: "TBA"

--- a/src/content/docs/events/2027/2027-04-12.mdx
+++ b/src/content/docs/events/2027/2027-04-12.mdx
@@ -13,6 +13,8 @@ artist: ["die ärzte"]
 
 category: "Konzert"
 
+organizer: "concert team Düsseldorf GmbH"
+
 ticketCategory: "Stehplatz Innenraum"
 
 support: "TBA"

--- a/src/content/docs/events/2027/2027-04-14.mdx
+++ b/src/content/docs/events/2027/2027-04-14.mdx
@@ -13,6 +13,8 @@ artist: ["die ärzte"]
 
 category: "Konzert"
 
+organizer: "concert team Düsseldorf GmbH"
+
 ticketCategory: "Stehplatz Innenraum"
 
 support: "TBA"

--- a/src/content/docs/events/2027/2027-12-11.mdx
+++ b/src/content/docs/events/2027/2027-12-11.mdx
@@ -8,6 +8,7 @@ description: "Eventbericht über das Konzert von Sondaschule in der Westfalenhal
 tour: "25 Jahre - Mega Circle Pott"
 artist: ["Sondaschule"]
 category: "Konzert"
+organizer: "Kingstar GmbH"
 ticketCategory: "Stehplatz Innenraum"
 support: "TBA"
 status: "scheduled"

--- a/src/data/organizers.mjs
+++ b/src/data/organizers.mjs
@@ -31,6 +31,14 @@ export const knownOrganizers = [
   'ZFR Event GmbH & Co. KG',
 ];
 
+const organizerUrls = new Map([
+  ['RADIO BOB GmbH & Co. KG', 'https://www.radiobob.de/'],
+  ['HockeyPark Betriebs GmbH & Co. KG', 'https://sparkassenpark.de/'],
+  ['ZFR Event GmbH & Co. KG', 'https://www.zeltfestivalruhr.de/'],
+  ['concert team Düsseldorf GmbH', 'https://www.concertteam.de/'],
+  ['Kingstar GmbH', 'https://www.kingstar-music.com/'],
+].map(([name, url]) => [normalize(name), url]));
+
 function normalize(value) {
   return String(value || '').trim().toLocaleLowerCase('de-DE');
 }
@@ -42,4 +50,8 @@ export function organizersFromTags(tags) {
     .filter(Boolean));
 
   return knownOrganizers.filter((organizer) => tagSet.has(normalize(organizer)));
+}
+
+export function organizerUrl(organizer) {
+  return organizerUrls.get(normalize(organizer)) ?? '';
 }

--- a/src/data/organizers.mjs
+++ b/src/data/organizers.mjs
@@ -36,6 +36,7 @@ const organizerUrls = new Map([
   ['HockeyPark Betriebs GmbH & Co. KG', 'https://sparkassenpark.de/'],
   ['ZFR Event GmbH & Co. KG', 'https://www.zeltfestivalruhr.de/'],
   ['concert team Düsseldorf GmbH', 'https://www.concertteam.de/'],
+  ['Concert Team Düsseldorf', 'https://www.concertteam.de/'],
   ['Kingstar GmbH', 'https://www.kingstar-music.com/'],
 ].map(([name, url]) => [normalize(name), url]));
 

--- a/src/data/organizers.mjs
+++ b/src/data/organizers.mjs
@@ -1,7 +1,9 @@
 export const knownOrganizers = [
   '1LIVE',
+  'RADIO BOB GmbH & Co. KG',
   'Concertbüro Zahlmann GmbH',
   'Concert Team Düsseldorf',
+  'concert team Düsseldorf GmbH',
   'Contra Promotion GmbH',
   'DBE Köln',
   'Dirk Becker Entertainment GmbH',
@@ -22,9 +24,11 @@ export const knownOrganizers = [
   'Skalar Entertainment GmbH',
   'Westfalen Events GmbH',
   'Westfalen Concerts GmbH',
+  'HockeyPark Betriebs GmbH & Co. KG',
   'WM-Stadt Gelsenkirchen',
   'WWRY Musical GmbH',
   'Zeltfestival Ruhr',
+  'ZFR Event GmbH & Co. KG',
 ];
 
 function normalize(value) {

--- a/src/scripts/lib/event-schema.mjs
+++ b/src/scripts/lib/event-schema.mjs
@@ -20,3 +20,27 @@ export function googleEventStatus(value) {
   return GOOGLE_EVENT_STATUSES[String(value || '').toLowerCase()]
     ?? GOOGLE_EVENT_STATUSES.scheduled;
 }
+
+export function googleEventOffer({ price, eventStatus, startDate, url, name }) {
+  const validFrom = isoDate(startDate);
+
+  if (
+    typeof price !== 'number'
+    || !Number.isFinite(price)
+    || !/^\d{4}-\d{2}-\d{2}$/.test(validFrom)
+  ) {
+    return null;
+  }
+
+  return {
+    '@type': 'Offer',
+    price,
+    priceCurrency: 'EUR',
+    availability: eventStatus === GOOGLE_EVENT_STATUSES.scheduled
+      ? 'https://schema.org/InStock'
+      : 'https://schema.org/SoldOut',
+    validFrom,
+    url,
+    ...(name ? { name } : {}),
+  };
+}

--- a/tests/seo/canonical-host.test.mjs
+++ b/tests/seo/canonical-host.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const htaccessPath = new URL('../../public/.htaccess', import.meta.url);
+
+test('www requests permanently redirect to the canonical non-www host', async () => {
+  const htaccess = await readFile(htaccessPath, 'utf8');
+
+  assert.match(htaccess, /RewriteCond %\{HTTP_HOST\} \^www\\\.mysteryland\\\.biz\$ \[NC\]/);
+  assert.match(
+    htaccess,
+    /RewriteRule \^ https:\/\/mysteryland\.biz%\{REQUEST_URI\} \[R=301,END,NE\]/,
+  );
+});
+

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -126,7 +126,7 @@ test('every current or future event has all required Google event fields', async
 
       const image = String(data.ogImage ?? '').trim();
       const imagePath = image.startsWith('/')
-        ? path.resolve('public', image.slice(1))
+        ? new URL(`../../public${image}`, import.meta.url)
         : '';
 
       if (!imagePath || !await fileExists(imagePath)) {

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -4,7 +4,7 @@ import path from 'node:path';
 import test from 'node:test';
 import YAML from 'yaml';
 
-import { organizersFromTags } from '../../src/data/organizers.mjs';
+import { organizerUrl, organizersFromTags } from '../../src/data/organizers.mjs';
 import {
   googleEventOffer,
   googleEventStatus,
@@ -63,10 +63,11 @@ test('offers without a finite price or valid validFrom date are omitted', () => 
   assert.equal(googleEventOffer({ ...baseOffer, price: 79.5, startDate: '' }), null);
 });
 
-test('every current or future event has an organizer and image for Google event markup', async () => {
+test('every current or future event has a linked organizer and image for Google event markup', async () => {
   const eventsRoot = path.resolve('src/content/docs/events');
   const yearDirectories = await readdir(eventsRoot, { withFileTypes: true });
   const missingOrganizers = [];
+  const organizersWithoutUrls = [];
   const missingImages = [];
 
   for (const yearDirectory of yearDirectories.filter((entry) => entry.isDirectory())) {
@@ -87,6 +88,12 @@ test('every current or future event has an organizer and image for Google event 
         missingOrganizers.push(`${yearDirectory.name}/${eventFile}`);
       }
 
+      for (const organizer of explicitOrganizers.length ? explicitOrganizers : inferredOrganizers) {
+        if (!organizerUrl(organizer)) {
+          organizersWithoutUrls.push(`${yearDirectory.name}/${eventFile}: ${organizer}`);
+        }
+      }
+
       const image = String(data.ogImage ?? '').trim();
       const imagePath = image.startsWith('/')
         ? path.resolve('public', image.slice(1))
@@ -99,6 +106,7 @@ test('every current or future event has an organizer and image for Google event 
   }
 
   assert.deepEqual(missingOrganizers, []);
+  assert.deepEqual(organizersWithoutUrls, []);
   assert.deepEqual(missingImages, []);
 });
 

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { readdir, readFile } from 'node:fs/promises';
+import { access, readdir, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import test from 'node:test';
 import YAML from 'yaml';
@@ -63,10 +63,11 @@ test('offers without a finite price or valid validFrom date are omitted', () => 
   assert.equal(googleEventOffer({ ...baseOffer, price: 79.5, startDate: '' }), null);
 });
 
-test('every current or future event has an organizer for Google event markup', async () => {
+test('every current or future event has an organizer and image for Google event markup', async () => {
   const eventsRoot = path.resolve('src/content/docs/events');
   const yearDirectories = await readdir(eventsRoot, { withFileTypes: true });
   const missingOrganizers = [];
+  const missingImages = [];
 
   for (const yearDirectory of yearDirectories.filter((entry) => entry.isDirectory())) {
     const yearRoot = path.join(eventsRoot, yearDirectory.name);
@@ -85,11 +86,30 @@ test('every current or future event has an organizer for Google event markup', a
       if (explicitOrganizers.length === 0 && inferredOrganizers.length === 0) {
         missingOrganizers.push(`${yearDirectory.name}/${eventFile}`);
       }
+
+      const image = String(data.ogImage ?? '').trim();
+      const imagePath = image.startsWith('/')
+        ? path.resolve('public', image.slice(1))
+        : '';
+
+      if (!imagePath || !await fileExists(imagePath)) {
+        missingImages.push(`${yearDirectory.name}/${eventFile}`);
+      }
     }
   }
 
   assert.deepEqual(missingOrganizers, []);
+  assert.deepEqual(missingImages, []);
 });
+
+async function fileExists(file) {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function values(value) {
   return (Array.isArray(value) ? value : [value])

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -65,11 +65,23 @@ test('offers without a finite price or validFrom date are omitted', () => {
 });
 
 test('every current or future event has all required Google event fields', async () => {
-  const eventsRoot = path.resolve('src/content/docs/events');
+  const eventsRoot = new URL('../../src/content/docs/events/', import.meta.url);
   const yearDirectories = await readdir(eventsRoot, { withFileTypes: true });
   const eventsWithInvalidDates = [];
   const eventsWithoutSupportedStatus = [];
   const missingOrganizers = [];
+  const organizersWithoutUrls = [];
+  const missingImages = [];
+
+  for (const yearDirectory of yearDirectories.filter((entry) => entry.isDirectory())) {
+    const yearRoot = new URL(`${yearDirectory.name}/`, eventsRoot);
+    const eventFiles = (await readdir(yearRoot)).filter((file) => file.endsWith('.mdx'));
+
+    for (const eventFile of eventFiles) {
+      const source = await readFile(new URL(eventFile, yearRoot), 'utf8');
+      const frontmatter = source.match(/^---\s*\n([\s\S]*?)\n---/);
+      assert.ok(frontmatter, `Missing frontmatter in ${yearDirectory.name}/${eventFile}`);
+
   const organizersWithoutUrls = [];
   const missingImages = [];
 

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 import { access, readdir, readFile } from 'node:fs/promises';
-import path from 'node:path';
 import test from 'node:test';
 import YAML from 'yaml';
 
@@ -79,18 +78,6 @@ test('every current or future event has all required Google event fields', async
 
     for (const eventFile of eventFiles) {
       const source = await readFile(new URL(eventFile, yearRoot), 'utf8');
-      const frontmatter = source.match(/^---\s*\n([\s\S]*?)\n---/);
-      assert.ok(frontmatter, `Missing frontmatter in ${yearDirectory.name}/${eventFile}`);
-
-  const organizersWithoutUrls = [];
-  const missingImages = [];
-
-  for (const yearDirectory of yearDirectories.filter((entry) => entry.isDirectory())) {
-    const yearRoot = path.join(eventsRoot, yearDirectory.name);
-    const eventFiles = (await readdir(yearRoot)).filter((file) => file.endsWith('.mdx'));
-
-    for (const eventFile of eventFiles) {
-      const source = await readFile(path.join(yearRoot, eventFile), 'utf8');
       const frontmatter = source.match(/^---\s*\n([\s\S]*?)\n---/);
       assert.ok(frontmatter, `Missing frontmatter in ${yearDirectory.name}/${eventFile}`);
 

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -6,6 +6,7 @@ import YAML from 'yaml';
 
 import { organizersFromTags } from '../../src/data/organizers.mjs';
 import {
+  googleEventOffer,
   googleEventStatus,
   isCurrentOrFutureEvent,
 } from '../../src/scripts/lib/event-schema.mjs';
@@ -30,6 +31,36 @@ test('only Google-supported event status values are emitted', () => {
   assert.equal(googleEventStatus('postponed'), 'https://schema.org/EventPostponed');
   assert.equal(googleEventStatus('scheduled'), 'https://schema.org/EventScheduled');
   assert.equal(googleEventStatus('completed'), 'https://schema.org/EventScheduled');
+});
+
+test('event offers always contain a valid validFrom date', () => {
+  const offer = googleEventOffer({
+    price: 79.5,
+    eventStatus: googleEventStatus('scheduled'),
+    startDate: new Date('2027-04-12T18:30:00Z'),
+    url: 'https://mysteryland.biz/events/2027/2027-04-12/',
+    name: 'Innenraum',
+  });
+
+  assert.deepEqual(offer, {
+    '@type': 'Offer',
+    price: 79.5,
+    priceCurrency: 'EUR',
+    availability: 'https://schema.org/InStock',
+    validFrom: '2027-04-12',
+    url: 'https://mysteryland.biz/events/2027/2027-04-12/',
+    name: 'Innenraum',
+  });
+});
+
+test('offers without a finite price or valid validFrom date are omitted', () => {
+  const baseOffer = {
+    eventStatus: googleEventStatus('scheduled'),
+    url: 'https://mysteryland.biz/events/2027/2027-04-12/',
+  };
+
+  assert.equal(googleEventOffer({ ...baseOffer, price: undefined, startDate: '2027-04-12' }), null);
+  assert.equal(googleEventOffer({ ...baseOffer, price: 79.5, startDate: '' }), null);
 });
 
 test('every current or future event has an organizer for Google event markup', async () => {

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -8,6 +8,7 @@ import { organizerUrl, organizersFromTags } from '../../src/data/organizers.mjs'
 import {
   googleEventOffer,
   googleEventStatus,
+  isoDate,
   isCurrentOrFutureEvent,
 } from '../../src/scripts/lib/event-schema.mjs';
 
@@ -66,6 +67,7 @@ test('offers without a finite price or valid validFrom date are omitted', () => 
 test('every current or future event has all required Google event fields', async () => {
   const eventsRoot = path.resolve('src/content/docs/events');
   const yearDirectories = await readdir(eventsRoot, { withFileTypes: true });
+  const eventsWithInvalidDates = [];
   const eventsWithoutSupportedStatus = [];
   const missingOrganizers = [];
   const organizersWithoutUrls = [];
@@ -82,6 +84,16 @@ test('every current or future event has all required Google event fields', async
 
       const data = YAML.parse(frontmatter[1]);
       if (!isCurrentOrFutureEvent(data.endDate ?? data.pubDate)) continue;
+
+      const startDate = isoDate(data.pubDate);
+      const endDate = isoDate(data.endDate ?? data.pubDate);
+      if (
+        !/^\d{4}-\d{2}-\d{2}$/.test(startDate)
+        || !/^\d{4}-\d{2}-\d{2}$/.test(endDate)
+        || endDate < startDate
+      ) {
+        eventsWithInvalidDates.push(`${yearDirectory.name}/${eventFile}: ${startDate}–${endDate}`);
+      }
 
       const status = String(data.status ?? '').trim().toLowerCase();
       if (!['scheduled', 'cancelled', 'postponed'].includes(status)) {
@@ -111,6 +123,7 @@ test('every current or future event has all required Google event fields', async
     }
   }
 
+  assert.deepEqual(eventsWithInvalidDates, []);
   assert.deepEqual(eventsWithoutSupportedStatus, []);
   assert.deepEqual(missingOrganizers, []);
   assert.deepEqual(organizersWithoutUrls, []);

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -54,7 +54,7 @@ test('event offers always contain a validFrom date', () => {
   });
 });
 
-test('offers without a finite price or valid validFrom date are omitted', () => {
+test('offers without a finite price or validFrom date are omitted', () => {
   const baseOffer = {
     eventStatus: googleEventStatus('scheduled'),
     url: 'https://mysteryland.biz/events/2027/2027-04-12/',

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -140,7 +140,9 @@ async function fileExists(file) {
 }
 
 function values(value) {
-  return (Array.isArray(value) ? value : [value])
-    .map((item) => String(item ?? '').trim())
-    .filter(Boolean);
+  return [...new Set((Array.isArray(value) ? value : [value])
+    .flatMap((item) => String(item || '').split(','))
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .filter((item) => item !== 'TBA'))];
 }

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -63,9 +63,10 @@ test('offers without a finite price or valid validFrom date are omitted', () => 
   assert.equal(googleEventOffer({ ...baseOffer, price: 79.5, startDate: '' }), null);
 });
 
-test('every current or future event has a linked organizer and image for Google event markup', async () => {
+test('every current or future event has all required Google event fields', async () => {
   const eventsRoot = path.resolve('src/content/docs/events');
   const yearDirectories = await readdir(eventsRoot, { withFileTypes: true });
+  const eventsWithoutSupportedStatus = [];
   const missingOrganizers = [];
   const organizersWithoutUrls = [];
   const missingImages = [];
@@ -81,6 +82,11 @@ test('every current or future event has a linked organizer and image for Google 
 
       const data = YAML.parse(frontmatter[1]);
       if (!isCurrentOrFutureEvent(data.endDate ?? data.pubDate)) continue;
+
+      const status = String(data.status ?? '').trim().toLowerCase();
+      if (!['scheduled', 'cancelled', 'postponed'].includes(status)) {
+        eventsWithoutSupportedStatus.push(`${yearDirectory.name}/${eventFile}: ${status || 'missing'}`);
+      }
 
       const explicitOrganizers = values(data.organizer);
       const inferredOrganizers = organizersFromTags(data.tags ?? []);
@@ -105,6 +111,7 @@ test('every current or future event has a linked organizer and image for Google 
     }
   }
 
+  assert.deepEqual(eventsWithoutSupportedStatus, []);
   assert.deepEqual(missingOrganizers, []);
   assert.deepEqual(organizersWithoutUrls, []);
   assert.deepEqual(missingImages, []);

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
 import test from 'node:test';
+import YAML from 'yaml';
 
+import { organizersFromTags } from '../../src/data/organizers.mjs';
 import {
   googleEventStatus,
   isCurrentOrFutureEvent,
@@ -27,3 +31,37 @@ test('only Google-supported event status values are emitted', () => {
   assert.equal(googleEventStatus('scheduled'), 'https://schema.org/EventScheduled');
   assert.equal(googleEventStatus('completed'), 'https://schema.org/EventScheduled');
 });
+
+test('every current or future event has an organizer for Google event markup', async () => {
+  const eventsRoot = path.resolve('src/content/docs/events');
+  const yearDirectories = await readdir(eventsRoot, { withFileTypes: true });
+  const missingOrganizers = [];
+
+  for (const yearDirectory of yearDirectories.filter((entry) => entry.isDirectory())) {
+    const yearRoot = path.join(eventsRoot, yearDirectory.name);
+    const eventFiles = (await readdir(yearRoot)).filter((file) => file.endsWith('.mdx'));
+
+    for (const eventFile of eventFiles) {
+      const source = await readFile(path.join(yearRoot, eventFile), 'utf8');
+      const frontmatter = source.match(/^---\s*\n([\s\S]*?)\n---/);
+      assert.ok(frontmatter, `Missing frontmatter in ${yearDirectory.name}/${eventFile}`);
+
+      const data = YAML.parse(frontmatter[1]);
+      if (!isCurrentOrFutureEvent(data.endDate ?? data.pubDate)) continue;
+
+      const explicitOrganizers = values(data.organizer);
+      const inferredOrganizers = organizersFromTags(data.tags ?? []);
+      if (explicitOrganizers.length === 0 && inferredOrganizers.length === 0) {
+        missingOrganizers.push(`${yearDirectory.name}/${eventFile}`);
+      }
+    }
+  }
+
+  assert.deepEqual(missingOrganizers, []);
+});
+
+function values(value) {
+  return (Array.isArray(value) ? value : [value])
+    .map((item) => String(item ?? '').trim())
+    .filter(Boolean);
+}

--- a/tests/seo/event-schema.test.mjs
+++ b/tests/seo/event-schema.test.mjs
@@ -34,7 +34,7 @@ test('only Google-supported event status values are emitted', () => {
   assert.equal(googleEventStatus('completed'), 'https://schema.org/EventScheduled');
 });
 
-test('event offers always contain a valid validFrom date', () => {
+test('event offers always contain a validFrom date', () => {
   const offer = googleEventOffer({
     price: 79.5,
     eventStatus: googleEventStatus('scheduled'),


### PR DESCRIPTION
## Summary
- Add canonical non-www redirects and require `.htaccess` during deployment
- Improve event JSON-LD offers with validated dates and organizer URLs
- Add organizer metadata to upcoming events
- Add regression coverage for canonical redirects and Google event requirements

## Testing
- Added automated SEO and event-schema validation tests