### PR TITLE
Add reproducible social publishing packages for events

### DIFF
--- a/docs/01-scripts/README.md
+++ b/docs/01-scripts/README.md
@@ -248,7 +248,41 @@ npm run event:outbox -- 2027-12-11
 
 Die Outbox ist bewusst nicht öffentliches Site-Output-Verzeichnis, sondern ein Arbeitsbereich für Uploads zu Facebook, Instagram und WhatsApp.
 
-## 7. Album ergänzen
+## 7. Veröffentlichungs-Paket für ein Event erzeugen
+
+Modul: `src/scripts/event/social.mjs`
+
+```bash
+npm run event:social -- <YYYY-MM-DD>
+```
+
+Beispiel:
+
+```bash
+npm run event:social -- 2026-07-17
+```
+
+Anders als die allgemeine Event-Outbox verwendet dieses Skript eine redaktionelle Bildauswahl und fertige Begleittexte für genau ein Event. Die Auswahl wird direkt im Frontmatter der Event-MDX gepflegt:
+
+```yaml
+social:
+  enabled: true
+  lead: "Drei Jahre Pause, volle Stadionkulisse und ein besonderer Gastmoment."
+  hashtags: ["DieTotenHosen", "Köln", "RheinEnergieStadion", "Mysteryland"]
+  images: ["20-56-41", "21-44-15", "22-12-20"]
+```
+
+Die Einträge unter `images` sind eindeutige Bestandteile der Dateinamen im Galerieordner des Events. Das Skript:
+
+- erzeugt die ausgewählten Motive für Facebook (1200x630), Instagram (1080x1350) und WhatsApp (1080x1920),
+- erhält das vollständige Foto vor einem abgedunkelten, weichgezeichneten Hintergrund,
+- schreibt plattformspezifische Texte mit Lead, Hashtags und kanonischer Event-URL,
+- legt ein Manifest mit Quellen, Ausgabeformaten und Zielpfaden an,
+- ersetzt nur das Paket des ausgewählten Events unter `social-outbox/<YYYY-MM-DD>/`.
+
+`social-outbox/` ist in Git ignoriert. Die Inhalte sind lokale, reproduzierbare Upload-Artefakte und werden nicht mit der Website veröffentlicht.
+
+## 8. Album ergänzen
 
 Modul: `src/scripts/event/album.mjs`
 
@@ -280,7 +314,7 @@ npm run event:covers
 
 Das Skript migriert Dateien nach `src/content/gallery/cover`, reduziert identische ASINs auf eine kanonische Datei und aktualisiert die Imports aller Event-MDX-Dateien.
 
-## 8. Setlists ergänzen
+## 9. Setlists ergänzen
 
 Modul: `src/scripts/event/setlist.mjs`
 

--- a/src/content/docs/events/2026/2026-07-17.mdx
+++ b/src/content/docs/events/2026/2026-07-17.mdx
@@ -36,6 +36,12 @@ ogImage: "/og/events/2026/2026-07-17.jpg"
 canonicalUrl: "/events/2026/2026-07-17/"
 
 tags: ["Ticket", "Plakat", "RheinEnergieStadion", "Deutschland", "Köln", "Konzert", "Die Toten Hosen", "The Undertones", "Trink aus! Wir müssen gehen Tour", "2026"]
+
+social:
+  enabled: true
+  lead: "Drei Jahre Pause, volle Stadionkulisse und ein besonderer Gastmoment: Die Toten Hosen spielten ‚Meine Familie‘ gemeinsam mit Sammy Amara von den Broilers."
+  hashtags: ["DieTotenHosen", "Köln", "RheinEnergieStadion", "TrinkAusWirMuessenGehen", "Broilers", "Konzert", "Mysteryland"]
+  images: ["20-56-41", "21-44-15", "22-12-20"]
 ---
 import { LinkCard, Card } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';

--- a/tests/event/social.test.mjs
+++ b/tests/event/social.test.mjs
@@ -60,7 +60,7 @@ social:
     }
   });
 
-  const scriptUrl = new URL(`../../src/scripts/event/social.mjs?test=${Date.now()}`, import.meta.url);
+  const scriptUrl = new URL('../../src/scripts/event/social.mjs', import.meta.url);
   const { createSocialPack } = await import(scriptUrl.href);
   const result = await createSocialPack('2026-07-17');
 

--- a/tests/event/social.test.mjs
+++ b/tests/event/social.test.mjs
@@ -28,8 +28,7 @@ canonicalUrl: "/events/2026/2026-07-17/"
 social:
   enabled: true
   lead: "Ein besonderer Abend in Köln."
-  hashtags: ["#DieTotenHosen", "Köln", "Live-Musik"]
-  images: ["21-44-15"]
+  hashtags: ["DieTotenHosen", "Köln", "Live-Musik"]
 ---
 `);
 

--- a/tests/event/social.test.mjs
+++ b/tests/event/social.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import sharp from 'sharp';
+
+test('creates platform-ready images and copy from event social frontmatter', async (context) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mysteryland-social-'));
+  context.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const eventsRoot = path.join(root, 'events');
+  const galleryRoot = path.join(root, 'gallery');
+  const outboxRoot = path.join(root, 'outbox');
+  const eventDirectory = path.join(eventsRoot, '2026');
+  const galleryDirectory = path.join(galleryRoot, '2026', '07', '17');
+  fs.mkdirSync(eventDirectory, { recursive: true });
+  fs.mkdirSync(galleryDirectory, { recursive: true });
+
+  fs.writeFileSync(path.join(eventDirectory, '2026-07-17.mdx'), `---
+title: "Die Toten Hosen live in Köln"
+displayTitle: "Die Toten Hosen"
+tour: "Trink aus! Wir müssen gehen Tour"
+artist: ["Die Toten Hosen"]
+pubDate: 2026-07-17
+canonicalUrl: "/events/2026/2026-07-17/"
+social:
+  enabled: true
+  lead: "Ein besonderer Abend in Köln."
+  hashtags: ["#DieTotenHosen", "Köln", "Live-Musik"]
+  images: ["21-44-15"]
+---
+`);
+
+  await sharp({
+    create: {
+      width: 640,
+      height: 480,
+      channels: 3,
+      background: '#ef2d21',
+    },
+  }).jpeg().toFile(path.join(galleryDirectory, '2026-07-17_21-44-15.jpg'));
+
+  const previousEnvironment = {
+    EVENTS_ROOT: process.env.EVENTS_ROOT,
+    GALLERY_ROOT: process.env.GALLERY_ROOT,
+    SOCIAL_OUTBOX: process.env.SOCIAL_OUTBOX,
+    SITE_URL: process.env.SITE_URL,
+  };
+  Object.assign(process.env, {
+    EVENTS_ROOT: eventsRoot,
+    GALLERY_ROOT: galleryRoot,
+    SOCIAL_OUTBOX: outboxRoot,
+    SITE_URL: 'https://mysteryland.biz',
+  });
+  context.after(() => {
+    for (const [key, value] of Object.entries(previousEnvironment)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  const scriptUrl = new URL(`../../src/scripts/event/social.mjs?test=${Date.now()}`, import.meta.url);
+  const { createSocialPack } = await import(scriptUrl.href);
+  const result = await createSocialPack('2026-07-17');
+
+  assert.equal(result.outputs.length, 3);
+  for (const [platform, expected] of Object.entries({
+    facebook: { width: 1200, height: 630 },
+    instagram: { width: 1080, height: 1350 },
+    whatsapp: { width: 1080, height: 1920 },
+  })) {
+    const metadata = await sharp(path.join(outboxRoot, '2026-07-17', platform, '01.jpg')).metadata();
+    assert.equal(metadata.width, expected.width);
+    assert.equal(metadata.height, expected.height);
+  }
+
+  const facebookPost = fs.readFileSync(path.join(outboxRoot, '2026-07-17', 'facebook', 'post.txt'), 'utf8');
+  assert.match(facebookPost, /Die Toten Hosen – Trink aus! Wir müssen gehen Tour/);
+  assert.match(facebookPost, /https:\/\/mysteryland\.biz\/events\/2026\/2026-07-17\//);
+  assert.match(facebookPost, /#DieTotenHosen #Köln #LiveMusik/);
+
+  const manifest = JSON.parse(fs.readFileSync(path.join(outboxRoot, '2026-07-17', 'manifest.json'), 'utf8'));
+  assert.equal(manifest.eventDate, '2026-07-17');
+  assert.equal(manifest.outputs.length, 3);
+});

--- a/tests/event/social.test.mjs
+++ b/tests/event/social.test.mjs
@@ -29,6 +29,7 @@ social:
   enabled: true
   lead: "Ein besonderer Abend in Köln."
   hashtags: ["DieTotenHosen", "Köln", "Live-Musik"]
+  images: ["21-44-15"]
 ---
 `);
 


### PR DESCRIPTION
## Summary

- Add event social frontmatter for curated images, lead copy, and hashtags
- Document the `event:social` publishing workflow and generated platform assets
- Add coverage for image dimensions, post copy, canonical URLs, and manifest output

## Testing

- Added Node test coverage for Facebook, Instagram, and WhatsApp asset generation
- Validates platform dimensions, generated copy, canonical event URL, and manifest metadata