### PR TITLE
Fix setlist syntax blocking deploy

### DIFF
--- a/src/scripts/event/setlist.mjs
+++ b/src/scripts/event/setlist.mjs
@@ -71,11 +71,9 @@ if (!sectionMatch) {
 }
 
 const placeholderCard = /<Card title="Songs" icon="list-format">\s*(?:TBA|TODO)\s*<\/Card>/;
-const existingTitles = (
-  [...sectionMatch[2].matchAll(/<Card title="([^"]+)" icon="list-format">/g)]
-    .map((match) => match[1])
-    .filter(Boolean),
-);
+const existingTitles = [...sectionMatch[2].matchAll(/<Card title="([^"]+)" icon="list-format">/g)]
+  .map((match) => match[1])
+  .filter(Boolean);
 const pendingArtists = event.artists.filter((artist) => {
   const exists = event.artists.length === 1
     ? existingTitles.some((title) => normalize(title) === 'songs') && !placeholderCard.test(sectionMatch[2])


### PR DESCRIPTION
Fixes the invalid parenthesized array expression introduced while addressing the setlist deduplication review. The artist titles remain an array for sameArtist matching, without the parser-invalid trailing comma.\n\nValidation:\n- npm run verify\n- Astro: 0 errors\n- TypeScript: passed\n- Tests: 19/19 passed\n- Production build: 373 pages