### PR TITLE
Add platform-specific Instagram social publishing configuration

### DIFF
--- a/src/content/docs/events/2026/2026-07-25.mdx
+++ b/src/content/docs/events/2026/2026-07-25.mdx
@@ -56,6 +56,16 @@ ogImage: "/og/events/2026/2026-07-25.jpg"
 canonicalUrl: "/events/2026/2026-07-25/"
 
 tags: ["Ticket", "Plakat", "Deutschland", "2026", "BOB!Fest", "Festival", "Mönchengladbach", "SparkassenPark", "Airbourne", "Judas Priest", "The Gems", "Phil Campbell’s Bastard Sons", "Nestor", "Beyond The Black"]
+
+social:
+  enabled: true
+  lead: "Sechs Bands, ein Festivaltag und für mich fast alles musikalisches Neuland: Das BOB!Fest 2026 wurde zu einer echten Live-Entdeckungsreise."
+  hashtags: ["BOBFest2026", "RADIOBOB", "Mönchengladbach", "RockFestival", "Konzertfotografie"]
+  images: ["20-51-24", "13-45-00", "14-14-32", "14-47-10", "16-18-30", "17-26-09", "19-05-26", "19-09-36", "20-41-38"]
+  instagram:
+    lead: "Sechs Bands, ein Festivaltag – und für mich fast alles musikalisches Neuland. Beim BOB!Fest 2026 in Mönchengladbach habe ich The Gems, Phil Campbell’s Bastard Sons, Nestor, Beyond The Black, Airbourne und Judas Priest zum ersten Mal live erlebt. Viele ihrer Songs kannte ich vorher kaum oder überhaupt nicht – gerade deshalb wurde dieser Tag zu einer echten Entdeckungsreise. Welche dieser Bands würdet ihr am liebsten live sehen?"
+    hashtags: ["BOBFest2026", "RADIOBOB", "Mönchengladbach", "RockFestival", "Konzertfotografie"]
+    images: ["20-51-24", "13-45-00", "14-14-32", "14-47-10", "16-18-30", "17-26-09", "19-05-26", "19-09-36", "20-41-38"]
 ---
 import { LinkCard, Card, CardGrid } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';

--- a/src/scripts/event/social.mjs
+++ b/src/scripts/event/social.mjs
@@ -28,6 +28,37 @@ function cleanHashtag(value) {
   return String(value).replace(/^#/, '').replace(/[^\p{L}\p{N}_]/gu, '');
 }
 
+function hashtagText(values) {
+  return (Array.isArray(values) ? values : [])
+    .map(cleanHashtag)
+    .filter(Boolean)
+    .map((tag) => `#${tag}`)
+    .join(' ');
+}
+
+function platformSocial(social, platform) {
+  return {
+    lead: social?.[platform]?.lead ?? social?.lead,
+    hashtags: social?.[platform]?.hashtags ?? social?.hashtags ?? [],
+    images: social?.[platform]?.images ?? social?.images ?? [],
+  };
+}
+
+export function validateInstagramConfig(config) {
+  if (!config.lead || !Array.isArray(config.images) || config.images.length === 0) {
+    throw new Error('social.instagram.lead and social.instagram.images are required');
+  }
+  if (config.images.length > 10) {
+    throw new Error('social.instagram.images supports at most 10 images');
+  }
+  if (!Array.isArray(config.hashtags)) {
+    throw new Error('social.instagram.hashtags must be an array');
+  }
+  if (config.hashtags.length > 5) {
+    throw new Error('social.instagram.hashtags supports at most 5 hashtags');
+  }
+}
+
 function eventUrl(data) {
   const canonical = data.canonicalUrl || `/events/${String(data.pubDate).slice(0, 4)}/${String(data.pubDate).slice(0, 10)}/`;
   return new URL(canonical, `${SITE_URL}/`).href;
@@ -67,16 +98,15 @@ async function renderImage(source, target, { width, height }) {
 
 function copyText(data, url) {
   const social = data.social ?? {};
+  const facebook = platformSocial(social, 'facebook');
+  const instagram = platformSocial(social, 'instagram');
   const artist = Array.isArray(data.artist) ? data.artist.join(', ') : data.artist;
-  const hashtags = (Array.isArray(social.hashtags) ? social.hashtags : [])
-    .map(cleanHashtag)
-    .filter(Boolean)
-    .map((tag) => `#${tag}`)
-    .join(' ');
+  const facebookHashtags = hashtagText(facebook.hashtags);
+  const instagramHashtags = hashtagText(instagram.hashtags);
   const heading = `${artist} – ${data.tour || data.displayTitle || data.title}`;
   return {
-    facebook: `${heading}\n\n${social.lead}\n\nDen vollständigen Konzertbericht mit Galerie, Videos und Setlist gibt es auf Mysteryland:\n${url}\n\n${hashtags}`,
-    instagram: `${heading} 🤘\n\n${social.lead}\n\nDen vollständigen Konzertbericht mit Galerie, Videos und Setlist findet ihr auf mysteryland.biz.\n\n${hashtags}`,
+    facebook: `${heading}\n\n${facebook.lead}\n\nDen vollständigen Konzertbericht mit Galerie, Videos und Setlist gibt es auf Mysteryland:\n${url}\n\n${facebookHashtags}`,
+    instagram: `${heading} 🤘\n\n${instagram.lead}\n\nDen vollständigen Konzertbericht mit Galerie, Videos und Setlist findet ihr auf mysteryland.biz.\n\n${instagramHashtags}`,
     whatsappStatus: `${heading}\n\n${social.lead}\n\nMehr auf mysteryland.biz`,
     whatsappMessage: `${heading}\n\n${social.lead}\n\nKonzertbericht, Bilder, Videos und Setlist:\n${url}`,
   };
@@ -87,6 +117,8 @@ export async function createSocialPack(eventDate) {
   const { filePath, data } = readEvent(eventDate);
   if (!data.social || data.social.enabled === false) throw new Error(`Social publishing is not enabled in ${filePath}`);
   if (!data.social.lead || !Array.isArray(data.social.images) || data.social.images.length === 0) throw new Error(`social.lead and social.images are required in ${filePath}`);
+  const instagram = platformSocial(data.social, 'instagram');
+  validateInstagramConfig(instagram);
 
   const targetRoot = path.join(OUTBOX_ROOT, eventDate);
   fs.rmSync(targetRoot, { recursive: true, force: true });
@@ -96,7 +128,8 @@ export async function createSocialPack(eventDate) {
   for (const [platform, preset] of Object.entries(presets)) {
     const directory = path.join(targetRoot, platform);
     fs.mkdirSync(directory, { recursive: true });
-    for (const [index, imageId] of data.social.images.entries()) {
+    const platformImages = platformSocial(data.social, platform).images;
+    for (const [index, imageId] of platformImages.entries()) {
       const source = findSourceImage(eventDate, imageId);
       const target = path.join(directory, `${String(index + 1).padStart(2, '0')}.jpg`);
       await renderImage(source, target, preset);

--- a/tests/event/social.test.mjs
+++ b/tests/event/social.test.mjs
@@ -30,6 +30,10 @@ social:
   lead: "Ein besonderer Abend in Köln."
   hashtags: ["DieTotenHosen", "Köln", "Live-Musik"]
   images: ["21-44-15"]
+  instagram:
+    lead: "Instagram: ein besonderer Abend in Köln."
+    hashtags: ["DieTotenHosen", "Köln"]
+    images: ["21-44-15"]
 ---
 `);
 
@@ -81,7 +85,26 @@ social:
   assert.match(facebookPost, /https:\/\/mysteryland\.biz\/events\/2026\/2026-07-17\//);
   assert.match(facebookPost, /#DieTotenHosen #Köln #LiveMusik/);
 
+  const instagramCaption = fs.readFileSync(path.join(outboxRoot, '2026-07-17', 'instagram', 'caption.txt'), 'utf8');
+  assert.match(instagramCaption, /Instagram: ein besonderer Abend in Köln\./);
+  assert.match(instagramCaption, /#DieTotenHosen #Köln/);
+  assert.doesNotMatch(instagramCaption, /#LiveMusik/);
+
   const manifest = JSON.parse(fs.readFileSync(path.join(outboxRoot, '2026-07-17', 'manifest.json'), 'utf8'));
   assert.equal(manifest.eventDate, '2026-07-17');
   assert.equal(manifest.outputs.length, 3);
+});
+
+test('enforces Instagram carousel and hashtag limits', async () => {
+  const scriptUrl = new URL('../../src/scripts/event/social.mjs', import.meta.url);
+  const { validateInstagramConfig } = await import(scriptUrl.href);
+
+  assert.throws(
+    () => validateInstagramConfig({ lead: 'Lead', images: Array.from({ length: 11 }, (_, index) => String(index)), hashtags: [] }),
+    /at most 10 images/,
+  );
+  assert.throws(
+    () => validateInstagramConfig({ lead: 'Lead', images: ['one'], hashtags: ['one', 'two', 'three', 'four', 'five', 'six'] }),
+    /at most 5 hashtags/,
+  );
 });


### PR DESCRIPTION
## Summary

- Support platform-specific social copy, hashtags, and image selections.
- Add Instagram carousel and hashtag validation.
- Configure platform-specific BOB!Fest 2026 Instagram content.
- Expand social workflow tests for Instagram overrides and limits.

## Testing

- Updated event social tests cover Instagram-specific captions, hashtags, image handling, and validation limits.